### PR TITLE
Fix: Improve user message text visibility in dark mode

### DIFF
--- a/frontend/src/components/messages/TextMessage.tsx
+++ b/frontend/src/components/messages/TextMessage.tsx
@@ -31,8 +31,8 @@ export function TextMessage({ text, isUser }: TextMessageProps) {
     >
       <div
         className={clsx("rounded-[20px]", {
-          "px-4 max-w-[90%] ml-4 text-stone--900 bg-[#ededed]": isUser,
-          "px-4 max-w-[90%] mr-4 text-black bg-white": !isUser,
+          "px-4 max-w-[90%] ml-4 text-stone-900 dark:text-stone-900 bg-[#ededed]": isUser, 
+          "px-4 max-w-[90%] mr-4 text-black bg-white dark:bg-gray-800 dark:text-white": !isUser, 
         })}
       >
         <ReactMarkdown components={{ a: CustomLink }}>{text}</ReactMarkdown>


### PR DESCRIPTION
This pull request updates the `TextMessage` component to improve support for dark mode by adding conditional styling for dark mode text and background colors.

Dark mode styling updates:

* [`frontend/src/components/messages/TextMessage.tsx`](diffhunk://#diff-a75a3d5109587b73932ae090dd4357ec3c5ee3cd373b43676e608ef49a4312cbL34-R35): Updated the `TextMessage` component to include `dark:text-stone-900` for user messages and `dark:bg-gray-800 dark:text-white` for non-user messages, ensuring proper text and background colors in dark mode.
Now:
![image](https://github.com/user-attachments/assets/3d0b67da-e14f-44fa-8fe0-b39fbbd61ae7)
Before:
![image](https://github.com/user-attachments/assets/52f2260a-75e9-4c8b-b267-ac279c66744c)
