### PR TITLE
Fix(front-end): fix wav recorder sample rate issue

### DIFF
--- a/frontend/src/hooks/useAudio.ts
+++ b/frontend/src/hooks/useAudio.ts
@@ -18,7 +18,7 @@ export function useAudio() {
 
   useEffect(() => {
     async function init() {
-      wavRecorder.current = new WavRecorder({ sampleRate: 24000 });
+      wavRecorder.current = new WavRecorder();
       await wavRecorder.current.begin();
       setAudioRecorderIsReady(true);
       wavPlayer.current = new WavStreamPlayer({ sampleRate: 24000 });


### PR DESCRIPTION
The code assumes that all audio sources will default to a sample rate of 24000 Hz. Remove this default value to cater for varying devices (`wavRecorder` defaults to 44100 Hz, which is the most common browser sample rate. See [here](https://github.com/keithwhor/wavtools/blob/main/lib/wav_recorder.js#L25)).

The default value was causing the error:

```
Unhandled Runtime Error

Error: AudioContext.createMediaStreamSource: Connecting AudioNodes from AudioContexts with different sample-rate is currently not supported.

node_modules/wavtools/lib/wav_recorder.js (325:28)
```

An example of the error I was getting can be seen below (this issue was occurring for multiple microphones):

<img width="2560" alt="SCR-20250501-nqwd" src="https://github.com/user-attachments/assets/a84dfd94-80a8-45e9-b6e0-815545c0075f" />

Once the change was made to the `wavRecorder` code the microphone/s worked as expected:

<img width="2560" alt="SCR-20250501-ntqi" src="https://github.com/user-attachments/assets/3a937a1e-bb05-4446-af9d-996a118de256" />
